### PR TITLE
Updated pytorch example

### DIFF
--- a/pytorch-examples/comet-pytorch-mnist-example.py
+++ b/pytorch-examples/comet-pytorch-mnist-example.py
@@ -4,6 +4,7 @@ import torchvision.datasets as dsets
 import torchvision.transforms as transforms
 from torch.autograd import Variable
 from comet_ml import Experiment
+import os
 
 hyper_params = {
     "sequence_length": 28,
@@ -42,13 +43,16 @@ class RNN(nn.Module):
         super(RNN, self).__init__()
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
+        self.lstm = nn.LSTM(input_size, hidden_size,
+                            num_layers, batch_first=True)
         self.fc = nn.Linear(hidden_size, num_classes)
 
     def forward(self, x):
         # Set initial states
-        h0 = Variable(torch.zeros(self.num_layers, x.size(0), self.hidden_size))
-        c0 = Variable(torch.zeros(self.num_layers, x.size(0), self.hidden_size))
+        h0 = Variable(torch.zeros(self.num_layers,
+                                  x.size(0), self.hidden_size))
+        c0 = Variable(torch.zeros(self.num_layers,
+                                  x.size(0), self.hidden_size))
 
         # Forward propagate RNN
         out, _ = self.lstm(x, (h0, c0))
@@ -58,14 +62,21 @@ class RNN(nn.Module):
         return out
 
 
-experiment = Experiment(api_key="YOUR-API-KEY", project_name='pytorch-examples')
+# Setting the API key (saved as environment variable)
+experiment = Experiment(
+    #api_key="YOUR API KEY",
+    # or
+    api_key=os.environ.get("COMET_API_KEY"),
+    project_name='comet-examples')
 experiment.log_multiple_params(hyper_params)
 
-rnn = RNN(hyper_params['input_size'], hyper_params['hidden_size'], hyper_params['num_layers'], hyper_params['num_classes'])
+rnn = RNN(hyper_params['input_size'], hyper_params['hidden_size'],
+          hyper_params['num_layers'], hyper_params['num_classes'])
 
 # Loss and Optimizer
 criterion = nn.CrossEntropyLoss()
-optimizer = torch.optim.Adam(rnn.parameters(), lr=hyper_params['learning_rate'])
+optimizer = torch.optim.Adam(
+    rnn.parameters(), lr=hyper_params['learning_rate'])
 
 # Train the Model
 
@@ -74,7 +85,8 @@ for epoch in range(hyper_params['num_epochs']):
     total = 0
     experiment.log_current_epoch(epoch)
     for i, (images, labels) in enumerate(train_loader):
-        images = Variable(images.view(-1, hyper_params['sequence_length'], hyper_params['input_size']))
+        images = Variable(
+            images.view(-1, hyper_params['sequence_length'], hyper_params['input_size']))
         labels = Variable(labels)
 
         # Forward + Backward + Optimize
@@ -89,10 +101,13 @@ for epoch in range(hyper_params['num_epochs']):
         total += labels.size(0)
         correct += (predicted == labels.data).sum()
 
+        print(correct.item())
+        print(total)
+
         # Log to Comet.ml
         experiment.set_step(i)
-        experiment.log_metric("loss", loss.data[0])
-        experiment.log_metric("accuracy", correct / total)
+        experiment.log_metric("loss", loss.item())
+        experiment.log_metric("accuracy", correct.item() / total)
 
         if (i + 1) % 100 == 0:
             print('Epoch [%d/%d], Step [%d/%d], Loss: %.4f'
@@ -102,11 +117,13 @@ for epoch in range(hyper_params['num_epochs']):
 correct = 0
 total = 0
 for images, labels in test_loader:
-    images = Variable(images.view(-1, hyper_params['sequence_length'], hyper_params['input_size']))
+    images = Variable(
+        images.view(-1, hyper_params['sequence_length'], hyper_params['input_size']))
     outputs = rnn(images)
     _, predicted = torch.max(outputs.data, 1)
     total += labels.size(0)
     correct += (predicted == labels).sum()
 
-experiment.log_metric("test_accuracy",100 * correct / total)
-print('Test Accuracy of the model on the 10000 test images: %d %%' % (100 * correct / total))
+experiment.log_metric("test_accuracy", 100 * correct / total)
+print('Test Accuracy of the model on the 10000 test images: %d %%' %
+      (100 * correct.item() / total))


### PR DESCRIPTION
- Changed Experiment constructor to use COMET_API_KEY environment variable
- Fixed bug in metrics reporting:

File "comet-pytorch-mnist-example.py", line 127, in <module>
    experiment.log_metric("test_accuracy", 100 * correct / total)
RuntimeError: value cannot be converted to type int64_t without overflow: inf
